### PR TITLE
Remove value check from print.blade.php

### DIFF
--- a/resources/views/vendor/datatables/print.blade.php
+++ b/resources/views/vendor/datatables/print.blade.php
@@ -17,9 +17,7 @@
             @foreach($data as $row)
                 <tr>
                     @foreach($row as $key => $value)
-                        @if (is_string($value))
                             <td>{!! $value !!}</td>
-                        @endif
                     @endforeach
                 </tr>
             @endforeach


### PR DESCRIPTION
If a row has an empty field, the column will not show on the print view, and therefore the columns will not line up properly.

I'm new to forking on GitHub, sorry if I am going about this the wrong way.
