### PR TITLE
Fixed 'cipher' value in config/app.php

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -80,7 +80,7 @@ return [
 
     'key' => env('APP_KEY', 'SomeRandomString'),
 
-    'cipher' => MCRYPT_RIJNDAEL_128,
+    'cipher' => 'AES-256-CBC',
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Currently, it's MCRYPT_RIJNDAEL_128 which causes an error:

> `Use of undefined constant MCRYPT_RIJNDAEL_128`

Fixed to the Laravel's default: `'AES-256-CBC'`.
